### PR TITLE
Added Environment param to use other instances

### DIFF
--- a/src/Connect-AzureADExporter.ps1
+++ b/src/Connect-AzureADExporter.ps1
@@ -15,9 +15,12 @@ $global:TenantID = $null
 function Connect-AzureADExporter {
     param(
         [Parameter(Mandatory = $false)]
-        [string] $TenantId = 'common'
+            [string] $TenantId = 'common',
+        [Parameter(Mandatory = $false)]
+            [ValidateSet("Global","China","USGovDoD","USGov","Germany")]
+            [string] $Environment = 'Global'
     )    
-    Connect-MgGraph -TenantId $TenantId -Scopes 'Directory.Read.All', 
+    Connect-MgGraph -TenantId $TenantId -Environment $Environment -Scopes 'Directory.Read.All', 
         'Policy.Read.All', 
         'IdentityProvider.Read.All', 
         'Organization.Read.All',


### PR DESCRIPTION
Added the Environment parameter to allow users to connect to other instance types, including Global (default), China, Germany, USGov, and USGovDod. Future improvements can use the Get-MgEnvironment commandlet to pull and validate the current list of instance names.