### PR TITLE
Allow child arrays of hashtables to be sorted

### DIFF
--- a/src/Export-AzureAD.ps1
+++ b/src/Export-AzureAD.ps1
@@ -81,7 +81,7 @@ Function Export-AzureAD {
         }
         # get all PIM elements
         if ($All -and ($graphUri -in "privilegedAccess/aadroles/resources","privilegedAccess/azureResources/resources")) {
-            $entry.Fitler = $null
+            $entry.Filter = $null
         }
     }
 

--- a/src/internal/ConvertTo-OrderedDictionary.ps1
+++ b/src/internal/ConvertTo-OrderedDictionary.ps1
@@ -21,7 +21,7 @@ function ConvertTo-OrderedDictionary
                 foreach ($Item in ($InputObject.GetEnumerator() | Sort-Object -Property Key)) {
                     if($Item){
                         $value = Get-ObjectProperty $Item 'Value'
-                        if($value -is [hashtable]){ #if child is a hashtable, sort it too
+                        if($value -is [hashtable] -or $value -is [array]){ #if child is a hashtable or array, sort it too
                             $Item.Value = ConvertTo-OrderedDictionary $value
                         }
                     }


### PR DESCRIPTION
Currently, hashtables within child arrays are not sorted, resulting in messy git diffs when running azureadexporter regularly.