### PR TITLE
Add missing appRoleAssignedTo to servicePrincipals

### DIFF
--- a/src/Get-AADExportDefaultSchema.ps1
+++ b/src/Get-AADExportDefaultSchema.ps1
@@ -705,6 +705,13 @@ function Get-AADExportDefaultSchema  {
                     ApplicationPermission = 'Directory.Read.All'
                 },
                 @{
+                    GraphUri = 'servicePrincipals/{id}/appRoleAssignedTo'
+                    Path = 'AppRoleAssignedTo'
+                    Tag = @('All', 'ServicePrincipals')
+                    DelegatedPermission = 'Directory.Read.All'
+                    ApplicationPermission = 'Directory.Read.All'
+                },
+                @{
                     GraphUri = 'servicePrincipals/{id}/oauth2PermissionGrants'
                     Path = 'Oauth2PermissionGrants'
                     Tag = @('All', 'ServicePrincipals')


### PR DESCRIPTION
The application assignment is important for monitoring
the configuration. Without it we cannot know which user can
access what application and how.