### PR TITLE
Update Connect-AzureADExporter.ps1 with dynamic tab autocomplete for environment name

### DIFF
--- a/src/Connect-AzureADExporter.ps1
+++ b/src/Connect-AzureADExporter.ps1
@@ -16,9 +16,12 @@ function Connect-AzureADExporter {
     param(
         [Parameter(Mandatory = $false)]
             [string] $TenantId = 'common',
-        [Parameter(Mandatory = $false)]
-            [ValidateSet("Global","China","USGovDoD","USGov","Germany")]
-            [string] $Environment = 'Global'
+        [Parameter(Mandatory=$false)]
+            [ArgumentCompleter( {
+                param ( $CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters )
+                (Get-MgEnvironment).Name
+            } )]
+            [string]$Environment
     )    
     Connect-MgGraph -TenantId $TenantId -Environment $Environment -Scopes 'Directory.Read.All', 
         'Policy.Read.All', 


### PR DESCRIPTION
Used ArgumentCompleter (backwards compatible with Windows PowerShell 5.1) to dynamically pull Azure environment names for tab autocomplete of the Environment parameter.

Resolves issue #22 (tab autocomplete for Azure environment names should not be hard  coded).