### PR TITLE
Remove extra '$' sign that gets added later

### DIFF
--- a/src/Get-AADExportAccessPackageResourceScopes.ps1
+++ b/src/Get-AADExportAccessPackageResourceScopes.ps1
@@ -17,5 +17,5 @@ Function Get-AADExportAccessPackageResourceScopes {
       [Parameter(Mandatory = $true)]
       [string[]]$Parents
   )
-    Invoke-Graph "identityGovernance/entitlementManagement/accessPackages/$($Parents[0])" -QueryParameters @{expand='accessPackageResourceRoleScopes($expand=accessPackageResourceRole,accessPackageResourceScope)'} -ApiVersion 'beta'
+    Invoke-Graph "identityGovernance/entitlementManagement/accessPackages/$($Parents[0])" -QueryParameters @{expand='accessPackageResourceRoleScopes(expand=accessPackageResourceRole,accessPackageResourceScope)'} -ApiVersion 'beta'
 }


### PR DESCRIPTION
There's an issue that the inner '$expand' is prepended with an urlencoded '$' (%24) when the graph API request is made. I'm not sure which component does this; perhaps the graph api library? Replacing the '$expand' with just 'expand' fixes the issue.

Closes #47 