### PR TITLE
Fix issue #103 not being able to fetch policyId for Entra Id custom role eligible assignments

### DIFF
--- a/src/command/Get-AzurePIMDirectoryRoles.ps1
+++ b/src/command/Get-AzurePIMDirectoryRoles.ps1
@@ -33,7 +33,7 @@
             if ($skipAssignmentSettings) {
                 $_ | select *, @{n = 'PrincipalName'; e = { $_.principal.displayName } }, @{n = 'RoleName'; e = { $_.roleDefinition.displayName } }
             } else {
-                $rules = Get-PIMDirectoryRoleAssignmentSetting -roleId $_.roleDefinitionId -dontBeautify
+                $rules = Get-PIMDirectoryRoleAssignmentSetting $_.roleDefinition.templateId -dontBeautify
 
                 $_ | select *, @{n = 'PrincipalName'; e = { $_.principal.displayName } }, @{n = 'RoleName'; e = { $_.roleDefinition.displayName } }, @{n = 'Policy'; e = { $rules } }
             }

--- a/src/command/Get-AzurePIMDirectoryRoles.ps1
+++ b/src/command/Get-AzurePIMDirectoryRoles.ps1
@@ -33,7 +33,7 @@
             if ($skipAssignmentSettings) {
                 $_ | select *, @{n = 'PrincipalName'; e = { $_.principal.displayName } }, @{n = 'RoleName'; e = { $_.roleDefinition.displayName } }
             } else {
-                $rules = Get-PIMDirectoryRoleAssignmentSetting $_.roleDefinition.templateId -dontBeautify
+                $rules = Get-PIMDirectoryRoleAssignmentSetting -roleId $_.roleDefinition.templateId -dontBeautify
 
                 $_ | select *, @{n = 'PrincipalName'; e = { $_.principal.displayName } }, @{n = 'RoleName'; e = { $_.roleDefinition.displayName } }, @{n = 'Policy'; e = { $rules } }
             }


### PR DESCRIPTION
Fix the issue in #103 

The script Get-AzurePIMDirectoryRoles.ps1 is fetching all roleEligibilityScheduleInstances then using the roleDefinitionId to fetch the policyId using this graph endpoint v1.0/policies/roleManagementPolicyAssignments to then get the rules for the role

The roleDefinitionId for Entra Id Custom Roles received from the "roleEligibilityScheduleInstances" call cannot be used for fetching the roleManagementPolicyAssignments

I've changed the 
`$rules = Get-PIMDirectoryRoleAssignmentSetting -roleId $_.roleDefinitionId -dontBeautify`
to use 
`$rules = Get-PIMDirectoryRoleAssignmentSetting $_.roleDefinition.templateId -dontBeautify`

I've tested the change in my environment, but please verify my PR in a environment with both eligible PIM assignments on BuiltIn role and on a Entra Id custom role