### PR TITLE
Fix permission scope for authenticationMethodConfigurations endpoints

### DIFF
--- a/src/Get-EEDefaultSchema.ps1
+++ b/src/Get-EEDefaultSchema.ps1
@@ -272,57 +272,57 @@ function Get-EEDefaultSchema  {
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/email'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/Email.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/fido2'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/FIDO2.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/microsoftAuthenticator'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/MicrosoftAuthenticator.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/sms'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/SMS.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/temporaryAccessPass'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/TemporaryAccessPass.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/softwareOath'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/SoftwareOath.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/voice'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/Voice.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/X509Certificate.json'
             Tag = @('All', 'Config', 'Policies')
-            DelegatedPermission = 'Policy.Read.All'
-            ApplicationPermission = 'Policy.Read.All'
+            DelegatedPermission = 'Policy.Read.AuthenticationMethod'
+            ApplicationPermission = 'Policy.Read.AuthenticationMethod'
         },
         @{
             GraphUri = 'policies/adminConsentRequestPolicy'


### PR DESCRIPTION
## Summary

- The 8 `authenticationMethodConfigurations` endpoints in `Get-EEDefaultSchema.ps1` declared `Policy.Read.All` as the required permission scope
- The Microsoft Graph API actually requires `Policy.Read.AuthenticationMethod` for these endpoints ([docs](https://learn.microsoft.com/en-us/graph/api/authenticationmethodconfiguration-get))
- `Policy.Read.All` and `Policy.Read.AuthenticationMethod` are separate scopes — `Policy.Read.All` does not cover authentication method policies
- This causes `Connect-EntraExporter` to not request the correct scope, resulting in **403 errors** on all authentication method configuration exports (email, fido2, microsoftAuthenticator, sms, temporaryAccessPass, softwareOath, voice, x509Certificate)

## Changes

Changed `DelegatedPermission` and `ApplicationPermission` from `Policy.Read.All` to `Policy.Read.AuthenticationMethod` for all 8 `authenticationMethodConfigurations` entries in `src/Get-EEDefaultSchema.ps1`.

## Test plan

- [x] Verified `Get-EERequiredScopes` now includes `Policy.Read.AuthenticationMethod` in the computed scopes
- [x] Ran `Export-Entra -All` against a production tenant — all 8 authentication method configuration endpoints exported successfully with zero 403 errors